### PR TITLE
Also auto-assign new issues to grantbevis

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -11,4 +11,4 @@ jobs:
         - name: 'Auto-assign issue'
           uses: pozil/auto-assign-issue@v4
           with:
-            assignees: modem7
+            assignees: modem7,grantbevis


### PR DESCRIPTION
## Summary
- New issues were only auto-assigned to modem7; add grantbevis as a second assignee.

## Test plan
- [ ] Open a test issue and confirm both modem7 and grantbevis get assigned