### PR TITLE
Fix stale settings.yml and align with current repo template

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,53 +2,66 @@
 # https://github.com/repository-settings/app
 
 repository:
-  description: CIBuildWheel
-  homepage: https://cloudsmith.io/~modem7/repos/wheels/packages/
-  topics: cibuildwheel, python, wheel, pypi
+  name: pypi
+  description: >-
+    CIBuildWheel repository for borgmatic-collective's Cloudsmith Python
+    packages. Built with cibuildwheel and hosted with Cloudsmith.
+  homepage: https://cloudsmith.io/~borgmatic-collective/repos/borgmatic/packages/
+  topics: cibuildwheel, python, wheel, pypi, borgmatic, cloudsmith
 
   private: false
   has_issues: true
   has_wiki: false
   has_downloads: true
   has_projects: false
+  has_discussions: false
 
-  default_branch: master
+  default_branch: main
 
   allow_squash_merge: true
   allow_rebase_merge: true
-  allow_merge_commit: false
-  
+  allow_merge_commit: true
+
+  # Auto-delete head branches after merge
+  delete_branch_on_merge: true
+
+  # Always suggest updating PR branches that are behind base
+  allow_update_branch: true
+
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
-  
+
+# Labels: define labels for Issues and Pull Requests
 labels:
-  - name: "bug"
-    color: "d73a4a"
+  - name: bug
+    color: d73a4a
     description: "Something isn't working"
-  - name: "dependencies"
-    color: "C62109"
+  - name: dependencies
+    color: C62109
     description: "Pull requests that update a dependency file"
-  - name: "documentation"
+  - name: documentation
     color: "0075ca"
     description: "Improvements or additions to documentation"
-  - name: "duplicate"
-    color: "cfd3d7"
+  - name: duplicate
+    color: cfd3d7
     description: "This issue or pull request already exists"
-  - name: "enhancement"
-    color: "a2eeef"
+  - name: enhancement
+    color: a2eeef
     description: "New feature or request"
-  - name: "good first issue"
+  - name: good first issue
     color: "7057ff"
     description: "Good for newcomers"
-  - name: "help wanted"
+  - name: help wanted
     color: "008672"
     description: "Extra attention is needed"
-  - name: "invalid"
-    color: "e4e669"
+  - name: invalid
+    color: e4e669
     description: "This doesn't seem right"
-  - name: "question"
-    color: "d876e3"
+  - name: question
+    color: d876e3
     description: "Further information is requested"
-  - name: "wontfix"
-    color: "#ffffff"
+  - name: wontfix
+    # was "#ffffff" in the uploaded file — leading # dropped, everything
+    # else in this list omits it and the app expects bare hex
+    color: ffffff
     description: "This will not be worked on"


### PR DESCRIPTION
## Summary
`.github/settings.yml` turned out to be an unedited copy of `cibuildwheel`'s old settings file (byte-identical, actually) — it described this repo as "CIBuildWheel", pointed `homepage` at modem7's personal Cloudsmith "wheels" repo, and — the more concerning one — had `default_branch: master`, which doesn't exist in this repo (the actual default branch is `main`). If the Settings app had ever applied that, it likely would have errored or tried to do something unexpected with the default branch.

Changes:
- `name`/`description`/`homepage`/`topics` now describe this repo and point at borgmatic-collective's actual Cloudsmith repo
- `default_branch` corrected to `main`
- Brought the rest of the structure in line with the current template (same as [modem7/cibuildwheel#77](https://github.com/modem7/cibuildwheel/pull/77)): `has_discussions`, `delete_branch_on_merge`, `allow_update_branch`, `allow_merge_commit: true`, cleaned-up label color quoting, fixed the `wontfix` color

## Test plan
- [ ] Merge and confirm the Settings app applies cleanly with no errors (particularly the `default_branch` fix)